### PR TITLE
fixed #21 sintax error, support any php 5+ or 7+

### DIFF
--- a/class.AttachmentPreviewPlugin.php
+++ b/class.AttachmentPreviewPlugin.php
@@ -644,25 +644,35 @@ class AttachmentPreviewPlugin extends Plugin {
     /**
      * Wrapper around log method
      */
-    private function debug_log($args) {
+    private function debug_log($text, $_=null) {
         if (self::DEBUG) {
+            $args = func_get_args();
             $text = array_shift($args);
-            $this->log($text, $args);
+            $this->log($text, $args); // send variable amount of args as array
         }
     }
 
-    /**
+        /**
      * Supports variable replacement of $text using sprintf macros
      *
-     * @param string $text
-     * @param mixed $args
+     * @param string $text with sprintf macros
+     * @param $_ any number of params for the macros
      */
-    private function log($text, $args=null) {
+    private function log($text, $_=null) {
         // Log to system, if available
         global $ost;
 
-        if (is_array($args) AND count($args) > 1) {
-            $text = vsprintf($text, $args);
+        $args = func_get_args(); 
+        $format = array_shift($args);
+        if(!$format){
+            return;
+        }
+        if(is_array($args[0])){ // handle debug_log or array of variables
+            $text = vsprintf($format,$args[0]);
+        }elseif(count($args)){ // handle normal variables as arguments
+            $text = vsprintf($format,$args);
+        }else{// no variables passed
+            $text = $format;
         }
 
         if (!$ost instanceof osTicket) {

--- a/class.AttachmentPreviewPlugin.php
+++ b/class.AttachmentPreviewPlugin.php
@@ -644,7 +644,7 @@ class AttachmentPreviewPlugin extends Plugin {
     /**
      * Wrapper around log method
      */
-    private function debug_log(...$args) {
+    private function debug_log($args) {
         if (self::DEBUG) {
             $text = array_shift($args);
             $this->log($text, $args);
@@ -657,12 +657,12 @@ class AttachmentPreviewPlugin extends Plugin {
      * @param string $text
      * @param mixed $args
      */
-    private function log($text, ...$args) {
+    private function log($text, $args=null) {
         // Log to system, if available
         global $ost;
 
-        if (func_num_args() > 1) {
-            $text = vsprintf($text, ...$args);
+        if (is_array($args) AND count($args > 1)) {
+            $text = vsprintf($text, $args);
         }
 
         if (!$ost instanceof osTicket) {

--- a/class.AttachmentPreviewPlugin.php
+++ b/class.AttachmentPreviewPlugin.php
@@ -661,7 +661,7 @@ class AttachmentPreviewPlugin extends Plugin {
         // Log to system, if available
         global $ost;
 
-        if (is_array($args) AND count($args > 1)) {
+        if (is_array($args) AND count($args) > 1) {
             $text = vsprintf($text, $args);
         }
 


### PR DESCRIPTION
the pluguin works perfect with osticket 1.9 but osticket 1.9 works with php 5.3 so able to work with any version.

i'll explain, if log parsing hav more that one arg, so the debug will parse and try to extract the rest of the arguments.. so no problem if are manage as array.. 

that's the reason why the secon arg its init with null to able to use with two or more on one arg only