### PR TITLE
Replaces #23, fixes #22, actually enables size filter

### DIFF
--- a/class.AttachmentPreviewPlugin.php
+++ b/class.AttachmentPreviewPlugin.php
@@ -214,11 +214,13 @@ class AttachmentPreviewPlugin extends Plugin {
                 // Luckily, the attachment link contains the filename.. which we can use!
                 // Grab the extension of the file from the filename:
                 $ext          = $this->getExtension($link->textContent);
-                $size_element = $xpath->query("following-sibling::*[1]", $link)->item[0];
+                $size_element = $xpath->query("following-sibling::*[1]", $link)->item(0);
+                
                 if ($size_element instanceof DomElement) {
-                    $size_kb = $this->unFormatSize($size_element->nodeValue);
-                    $this->debug_log("Attachment is roughly: " . $size_kb . ' bytes in size.');
-                    if ($config->get('attachment-size') < (int) ($size_kb / 1024)) {
+                    $size_b = $this->unFormatSize($size_element->nodeValue);
+                    $this->debug_log("$ext is roughly: $size_b bytes in size.");
+                    $size_kb = $size_b / 1024; 
+                    if ($size_kb > (int) $config->get('attachment-size')) {
                         // Skip this one, got a bit of an ass on it!
                         $this->debug_log("Skipping attachment, size filter");
                         continue;

--- a/class.AttachmentPreviewPlugin.php
+++ b/class.AttachmentPreviewPlugin.php
@@ -214,7 +214,7 @@ class AttachmentPreviewPlugin extends Plugin {
                 // Luckily, the attachment link contains the filename.. which we can use!
                 // Grab the extension of the file from the filename:
                 $ext          = $this->getExtension($link->textContent);
-                $size_element = $xpath->query("following-sibling::*[1]", $link)[0];
+                $size_element = $xpath->query("following-sibling::*[1]", $link)->item[0];
                 if ($size_element instanceof DomElement) {
                     $size_kb = $this->unFormatSize($size_element->nodeValue);
                     $this->debug_log("Attachment is roughly: " . $size_kb . ' bytes in size.');

--- a/tests/AttachmentPreviewPluginTest.php
+++ b/tests/AttachmentPreviewPluginTest.php
@@ -159,4 +159,47 @@ final class AttachmentPreviewPluginTest extends TestCase {
         $this->assertSame(AttachmentPreviewPlugin::isPjax(), TRUE);
     }
 
+    /**
+     * Does our function work?
+     * @dataProvider getByteSizedStrings
+     */
+    public function testUnformatSize($input, $expected) {
+        $out = $this->invokeMethod($this->plugin, 'unFormatSize', array($input));
+        $this->assertEquals($out, $expected);
+    }
+
+    /**
+     * Naively assumes the string is a MB rather than MiB type data-size
+     */
+    public function getByteSizedStrings() {
+
+        return [
+            // osticket string representation of size, number of bytes
+            ['1 bytes', 1],
+            ['444 bytes', 444],
+            ['1 kb', 1024],
+            ['122 kb', 124928],
+            ['1 mb', 1048576],
+            ['12 mb', 12582912]
+        ];
+    }
+
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     * @see https://jtreminio.com/2013/03/unit-testing-tutorial-part-3-testing-protected-private-methods-coverage-reports-and-crap/
+     */
+    public function invokeMethod(&$object, $methodName, array $parameters = array()) {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method     = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
 }


### PR DESCRIPTION
The DOMXPath->query method's output is not an array, however, we can call the item method on the object it returns, not access an array property called item.. close mate! :-). 
Also, added tests because I wasn't sure the unformat method was even working at all as the filter part wasn't, so, now the filter works!

Apparently I haven't figured out how to push to a PR yet.. 