### PR TITLE
Fixed #44 - HTML code displayed on page with osTicket v1.14.1

### DIFF
--- a/class.AttachmentPreviewPlugin.php
+++ b/class.AttachmentPreviewPlugin.php
@@ -1056,10 +1056,12 @@ class AttachmentPreviewPlugin extends Plugin {
       // URL contains a=edit or a=print, so assume we aren't needed here!
       $tickets_view = FALSE;
     }
-    elseif (strpos($url, 'index.php') !== FALSE ||
-      strpos($url, 'tickets.php') !== FALSE) {
-      // Might be a ticket page..
-      $tickets_view = TRUE;
+    elseif 
+	 // URL contains a ticket ID and page is index.php or tickets.php, we are viewing a ticket
+     (strpos($url, 'id=') !== FALSE &&
+	 (strpos($url, 'index.php') !== FALSE ||
+      strpos($url, 'tickets.php') !== FALSE))  {      
+		$tickets_view = TRUE;
     }
     else {
       // Default


### PR DESCRIPTION
Fixed function **isTicketsView()** so it checks for an **ID=** in the URL.
Without this, this plugin doesn't work in osTicket (v1.14.1)